### PR TITLE
fix(chore): was already done ez pz

### DIFF
--- a/internal/services/watcher.go
+++ b/internal/services/watcher.go
@@ -31,7 +31,6 @@ func NewWatcher(sharedService *Shared, playerStateWebsocketHandler *models.Playe
 }
 
 func (w *Watcher) StartPlayerStateLoop() {
-	//TODO: Add a loop restart if error occours
 	w.ctx = context.Background()
 
 	for {


### PR DESCRIPTION
This pull request includes a minor change to the `internal/services/watcher.go` file. The change involves removing a TODO comment regarding the addition of a loop restart in case of an error.

* [`internal/services/watcher.go`](diffhunk://#diff-a86f92300c7bb4cbde94e49742d66632de68e7a134234288ed66bdfed794f953L34): Removed a TODO comment that suggested adding a loop restart if an error occurs.

Resolves #108