### PR TITLE
ci(cache): try to add github actions cache to test workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4  
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: Env
+        run: |
+          # ACTIONS_RUNTIME_TOKEN, ACTIONS_RUNTIME_URL should be exposed
+          env|sort
       - name: Call Backend Publish Function
-        uses: dagger/dagger-for-github@v7
+        uses: rustic-beans/dagger-for-github@main
         with:
           version: "0.15.3"
           verb: call
           args: publish-github --source=. --registry=$DOCKER_REGISTRY --image-name=$DOCKER_IMAGE_NAME --username=$DOCKER_USERNAME --password=env:DOCKER_PASSWORD --tag=$DOCKER_TAG
+          cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
           DOCKER_REGISTRY: ghcr.io
           DOCKER_IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -22,12 +22,10 @@ jobs:
         with:
           version: "0.15.3"
           verb: call
-          args: build --source=. -vvv
+          args: build --source=.
           cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          export_logs: "true"
           # Maybe add this back if we want to see cool output
-          #
-          #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #
           

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -17,13 +17,13 @@ jobs:
           # ACTIONS_RUNTIME_TOKEN, ACTIONS_RUNTIME_URL should be exposed
           env|sort
       - name: Call Backend Test Function
-        uses: dagger/dagger-for-github@v7
-        env:
-            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+        # Pin at some point
+        uses: rustic-beans/dagger-for-github
         with:
           version: "0.15.3"
           verb: call
           args: build --source=.
+          cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
           # Maybe add this back if we want to see cool output
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -18,7 +18,7 @@ jobs:
           env|sort
       - name: Call Backend Test Function
         # Pin at some point
-        uses: rustic-beans/dagger-for-github
+        uses: rustic-beans/dagger-for-github@main
         with:
           version: "0.15.3"
           verb: call

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Call Backend Test Function
         uses: dagger/dagger-for-github@v7
         env:
-            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=$ACTIONS_RUNTIME_URL,token=$ACTIONS_RUNTIME_TOKEN"
+            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=$ACTIONS_CACHE_URL,token=$ACTIONS_RUNTIME_TOKEN"
         with:
           version: "0.15.3"
           verb: call

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -24,6 +24,7 @@ jobs:
           verb: call
           args: build --source=. -vvv
           cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           # Maybe add this back if we want to see cool output
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Call Backend Test Function
         uses: dagger/dagger-for-github@v7
         env:
-            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=$ACTIONS_CACHE_URL,token=$ACTIONS_RUNTIME_TOKEN"
+            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
         with:
           version: "0.15.3"
           verb: call

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -27,6 +27,7 @@ jobs:
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           export_logs: "true"
           # Maybe add this back if we want to see cool output
+          #
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #
           

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -10,8 +10,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4  
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: Env
+        run: |
+          # ACTIONS_RUNTIME_TOKEN, ACTIONS_RUNTIME_URL should be exposed
+          env|sort
       - name: Call Backend Test Function
         uses: dagger/dagger-for-github@v7
+        env:
+            _EXPERIMENTAL_DAGGER_CACHE_CONFIG: "type=gha,mode=max,url=$ACTIONS_RUNTIME_URL,token=$ACTIONS_RUNTIME_TOKEN"
         with:
           version: "0.15.3"
           verb: call

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           version: "0.15.3"
           verb: call
-          args: build --source=.
+          args: build --source=. -vvv
           cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
           # Maybe add this back if we want to see cool output
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -25,6 +25,7 @@ jobs:
           args: build --source=. -vvv
           cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          export_logs: true
           # Maybe add this back if we want to see cool output
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -25,7 +25,7 @@ jobs:
           args: build --source=. -vvv
           cache_config: "type=gha,mode=max,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          export_logs: true
+          export_logs: "true"
           # Maybe add this back if we want to see cool output
           #cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           #


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow to expose the GitHub runtime environment variables and use them in the backend test function.

Changes to GitHub Actions workflow:

* [`.github/workflows/test_on_push.yml`](diffhunk://#diff-2fbc801faaed9a628483d63edb74d7c5cc8af99f1a311dd46d18e5fe198fbcacR13-R22): Added steps to expose GitHub runtime environment variables (`ACTIONS_RUNTIME_TOKEN` and `ACTIONS_RUNTIME_URL`) and set them as environment variables for the backend test function.