### PR TITLE
docs(log): add logging when broadcasting to channel

### DIFF
--- a/internal/infrastructure/http/websocket_handler.go
+++ b/internal/infrastructure/http/websocket_handler.go
@@ -43,6 +43,7 @@ func (w *WebsocketHandler[M]) Broadcast(m M) {
 	defer w.mu.RUnlock()
 
 	for range w.numOfConn {
+		utils.Logger.Debug("Broadcasting message to connection")
 		w.connection <- m
 	}
 


### PR DESCRIPTION
This pull request includes a small change to the `internal/infrastructure/http/websocket_handler.go` file. The change adds a debug log statement to the `Broadcast` method to log when a message is being broadcast to a connection. 

* [`internal/infrastructure/http/websocket_handler.go`](diffhunk://#diff-d708e6ca2767ee1a5ac28fef3aebd185a392cf18f9fbe0867becf5e45b88d004R46): Added a debug log statement in the `Broadcast` method to log when a message is being broadcast to a connection.