### PR TITLE
Cache playerstate

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 		utils.Logger.Fatal("failed reading config", zap.Error(err))
 	}
 
-	playerStateWebsocketHandler := httpLib.NewWebsocketHandler[*models.PlayerState]()
+	playerStateWebsocketHandler := httpLib.NewWebsocketHandler[*models.PlayerState](config.Server.QueueSize)
 
 	dbClient := database.Connect(config)
 	databaseService := services.NewDatabase(dbClient)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -5,6 +5,7 @@ spotify:
 server:
   host: 0.0.0.0
   port: 8080
+  queueSize: 15
 database:
   driver: postgres
   source: "postgres://postgres:root@0.0.0.0:5432/spotify_db?sslmode=disable"

--- a/internal/infrastructure/http/websocket_handler.go
+++ b/internal/infrastructure/http/websocket_handler.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/rustic-beans/spotify-viewer/internal/utils"
+	"go.uber.org/zap"
 )
 
 type WebsocketHandler[M any] struct {
@@ -14,7 +15,7 @@ type WebsocketHandler[M any] struct {
 
 func NewWebsocketHandler[M any]() *WebsocketHandler[M] {
 	return &WebsocketHandler[M]{
-		connection: make(chan M),
+		connection: make(chan M, 15),
 	}
 }
 
@@ -42,6 +43,7 @@ func (w *WebsocketHandler[M]) Broadcast(m M) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
+	utils.Logger.Info("Lock acquired", zap.Int("numOfConn", w.numOfConn), zap.Int("Queue length", len(w.connection)))
 	for range w.numOfConn {
 		w.connection <- m
 	}

--- a/internal/infrastructure/http/websocket_handler.go
+++ b/internal/infrastructure/http/websocket_handler.go
@@ -13,9 +13,9 @@ type WebsocketHandler[M any] struct {
 	connection chan M
 }
 
-func NewWebsocketHandler[M any]() *WebsocketHandler[M] {
+func NewWebsocketHandler[M any](messageQueueSize int) *WebsocketHandler[M] {
 	return &WebsocketHandler[M]{
-		connection: make(chan M, 15),
+		connection: make(chan M, messageQueueSize),
 	}
 }
 
@@ -44,6 +44,7 @@ func (w *WebsocketHandler[M]) Broadcast(m M) {
 	defer w.mu.RUnlock()
 
 	utils.Logger.Info("Lock acquired", zap.Int("numOfConn", w.numOfConn), zap.Int("Queue length", len(w.connection)))
+
 	for range w.numOfConn {
 		w.connection <- m
 	}

--- a/internal/resolver/playerState.resolvers.go
+++ b/internal/resolver/playerState.resolvers.go
@@ -29,5 +29,13 @@ func (r *subscriptionResolver) PlayerState(ctx context.Context) (<-chan *models.
 		utils.Logger.Info("PlayerState subscription closed", zap.Any("context", ctx))
 	}()
 
+	utils.Logger.Debug("Getting PlayerState")
+	playerState, err := r.SharedService.GetPlayerState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	utils.Logger.Debug("Got PlayerState, broadcasting", zap.Any("playerState", playerState))
+	r.PlayerStateWebsocketHandler.Broadcast(playerState)
+
 	return ch, nil
 }

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"sync"
+	"time"
+)
+
+// SingleValueCache implements a simple cache that stores a single value
+// with optional expiration.
+type SingleValueCache[T any] struct {
+	mu        sync.RWMutex
+	value     T
+	expiresAt time.Time
+	hasValue  bool
+}
+
+// NewSingleValueCache creates a new instance of a single value cache.
+func NewSingleValueCache[T any]() *SingleValueCache[T] {
+	return &SingleValueCache[T]{}
+}
+
+// SetWithExpiry stores a value in the cache with an expiration duration.
+func (c *SingleValueCache[T]) SetWithExpiry(value T, expiry time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.value = value
+	c.hasValue = true
+	c.expiresAt = time.Now().Add(expiry)
+}
+
+// Get retrieves the stored value from the cache.
+// Returns the value and a boolean indicating if the value was found and not expired.
+func (c *SingleValueCache[T]) Get() (T, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var zero T
+
+	if !c.HasValue() {
+		return zero, false
+	}
+
+	return c.value, true
+}
+
+// Clear removes the value from the cache.
+func (c *SingleValueCache[T]) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.hasValue = false
+
+	var zero T
+	c.value = zero
+}
+
+// HasValue returns whether the cache currently has a valid value.
+func (c *SingleValueCache[T]) HasValue() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if !c.hasValue || time.Now().After(c.expiresAt) {
+		return false
+	}
+
+	return true
+}
+
+// TimeToExpiry returns the duration until expiration.
+// If the value has no expiry or is already expired, returns -1.
+func (c *SingleValueCache[T]) TimeToExpiry() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if !c.HasValue() {
+		return -1
+	}
+
+	remaining := time.Until(c.expiresAt)
+
+	return remaining
+}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -17,8 +17,9 @@ type Config struct {
 		TokenLocation string `mapstructure:"tokenLocation"`
 	}
 	Server struct {
-		Host string `mapstructure:"host"`
-		Port int    `mapstructure:"port"`
+		Host      string `mapstructure:"host"`
+		Port      int    `mapstructure:"port"`
+		QueueSize int    `mapstructure:"queueSize"`
 	} `mapstructure:"server"`
 	Database struct {
 		Driver string `mapstructure:"driver"`


### PR DESCRIPTION
### Logging Enhancements:
* [`internal/infrastructure/http/websocket_handler.go`](diffhunk://#diff-d708e6ca2767ee1a5ac28fef3aebd185a392cf18f9fbe0867becf5e45b88d004R46): Added logging statements to track when a lock is acquired and the number of connections and queue length.
* [`internal/resolver/playerState.resolvers.go`](diffhunk://#diff-36e20a003c7ef54f15bf52d35e8cb610767ffec0b80704f59b5b7309a58cf738R32-R39): Added debug logging statements to track the process of getting and broadcasting the player state.

### Caching Implementation:
* [`internal/services/spotify.go`](diffhunk://#diff-21c9a5d619903bc7af9938f47ab02ee33d8a54422a39dd6797b94c81cba3b296R6-R31): Implemented caching for the player state with a 5-second expiry to reduce redundant API calls. [[1]](diffhunk://#diff-21c9a5d619903bc7af9938f47ab02ee33d8a54422a39dd6797b94c81cba3b296R6-R31) [[2]](diffhunk://#diff-21c9a5d619903bc7af9938f47ab02ee33d8a54422a39dd6797b94c81cba3b296R48-R50)

### Channel Management:
* [`internal/infrastructure/http/websocket_handler.go`](diffhunk://#diff-d708e6ca2767ee1a5ac28fef3aebd185a392cf18f9fbe0867becf5e45b88d004L17-R18): Changed the WebSocket handler to use a buffered channel with a capacity of 15 to improve message handling.

### Import Statements:
* [`internal/infrastructure/http/websocket_handler.go`](diffhunk://#diff-d708e6ca2767ee1a5ac28fef3aebd185a392cf18f9fbe0867becf5e45b88d004R7): Added the `zap` package for structured logging.
* [`internal/services/spotify.go`](diffhunk://#diff-21c9a5d619903bc7af9938f47ab02ee33d8a54422a39dd6797b94c81cba3b296R6-R31): Added the `time` and `zap` packages for caching and logging purposes.