### PR TITLE
feat(cover): default to object-contain, but cover if ?cover=true

### DIFF
--- a/web/src/components/Player.vue
+++ b/web/src/components/Player.vue
@@ -6,6 +6,7 @@ import Controls from '@/components/Controls.vue';
 import ProgressBar from '@/components/ProgressBar.vue';
 import { type FragmentType, useFragment, graphql } from '@/__generated__';
 import { computed } from 'vue';
+import { useRoute } from 'vue-router';
 
 const PlayerStateFragment = graphql(/* GraphQL */ `
   fragment PlayerState on PlayerState {
@@ -32,13 +33,15 @@ const backgroundObj = computed(() => trackObj.value?.album);
 //TODO: once we have the artist image from the spotify api call, we can use the obj dominant color for this
 var color = "#821271";
 
-
+const query = useRoute().query;
+const coverMode = computed(() => (query.cover ?? 'false') === 'true');
 </script>
 
 <template>
   <div class="fixed inset-0">
     <Background
-      class="object-cover h-full w-full "
+      :class="{ 'object-cover': coverMode, 'object-contain': !coverMode }"
+      class=" h-full w-full "
       v-if="backgroundObj"
       :fragment="backgroundObj"
     />


### PR DESCRIPTION
Based on feedback we think the album background property should be `object-contain` instead of `object-cover`. It might still be useful to keep the cover mode for some viewings so if the `cover=true` query parameter is set we will `object-cover`.

Closes #135 