### PR TITLE
Handle when spotify doesn't return any images

### DIFF
--- a/internal/spotify/model_binding.go
+++ b/internal/spotify/model_binding.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getImageURL(images []spotify.Image) string {
-	if images == nil {
+	if len(images) == 0 {
 		return ""
 	}
 


### PR DESCRIPTION
This fixes a series of random crashes we've been experiencing. Some artists don't have any images and therefore this section of code caused a index of bounds error
